### PR TITLE
Convert colorSettins attribute in ImageData interface to a getter method

### DIFF
--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -159,7 +159,8 @@ interface ImageData {
   readonly attribute unsigned long width;
   readonly attribute unsigned long height;
   readonly attribute ImageDataArray data;
-  readonly attribute ImageDataColorSettings colorAttributes;
+  
+  ImageDataColorSettings getColorSettings();
 };
 </pre>
 

--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -159,7 +159,7 @@ interface ImageData {
   readonly attribute unsigned long width;
   readonly attribute unsigned long height;
   readonly attribute ImageDataArray data;
-  readonly attribute ImageDataColorSettings imageDataColorAttributes;
+  readonly attribute ImageDataColorSettings colorAttributes;
 };
 </pre>
 

--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -139,7 +139,7 @@ ImageBitmap objects are augmented to have an internal color space attribute of t
 IDL
 <pre>
 
-enum ImageDataStorageFormat {
+enum ImageDataStorageType {
   "uint8", // default
   "uint16",
   "float32",
@@ -149,7 +149,7 @@ typedef (Uint8ClampedArray or Uint16ClampedArray or Float32Array) ImageDataArray
 
 dictionary ImageDataColorSettings {
   CanvasColorSpace colorSpace = "srgb";
-  ImageDataStorageFormat storageFormat = "uint8";
+  ImageDataStorageType storageType = "uint8";
 };
 
 [Constructor(unsigned long sw, unsigned long sh, optional ImageDataColorSettings imageDataColorSettings),
@@ -163,10 +163,9 @@ interface ImageData {
 };
 </pre>
 
-* When using the constructor with ImageDataArray parameter, the array type must respect ImageDataColorSettings.ImageDataStorageFormat. Otherwise, the return object will be undefined.
+* When using the constructor that takes an ImageDataArray parameter, the "storageType" setting is ignored.
 * getImageData() produces an ImageData object with the same color space as the source canvas, using an ImageDataArray of a type that is appropriate for the pixelFormat of the source canvas (smallest possible numeric size that guarantees no loss of precision).
 * putImageData() performs a color space conversion to the color space of the destination canvas.
-* The proper ImageDataStorageFormat for "10-10-10-2" and "12-12-12-12" canvas pixel formats is "uint16". getImageData() and putImageData() use bit shifting for numerical scaling.
 
 ### Limitations 
 * toDataURL and toBlob are lossy, depending on the file format, when used on a canvas that has a pixelFormet other than 8-8-8-8. Possible future improvements could solve or mitigate this issue by adding more file formats or adding options to specify the resource color space.


### PR DESCRIPTION
ImageDataColorSettings is a dictionary, so it must not be used as the type of an attribute. This change fixes this by converting the colorSettings attribute in ImageData interface to a getter method.