### PR TITLE
Split out attribs into [color-space, encoding, linearity]

### DIFF
--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -245,4 +245,6 @@ This propsal was originally incubated in the WHATWG github issue tracker and inc
 
 This proposal was further discussed in the Khronos WebGL working group, with the participation of engineers from Apple, Google, Microsoft, Mozilla, Nvidia, and others.
 
-The current venue for discussing this proposal is a [W3C WICG Discourse thread](https://discourse.wicg.io/t/canvas-color-spaces-wide-gamut-and-high-bit-depth-rendering/1505)
+From 2016 to 2017, it was discussed on the [W3C WICG Discourse thread](https://discourse.wicg.io/t/canvas-color-spaces-wide-gamut-and-high-bit-depth-rendering/1505).
+
+The current venue for discussing this proposal is in issues and pull requests to the [WICG canvas-color-space GitHub repo](https://github.com/WICG/canvas-color-space).


### PR DESCRIPTION
There's renewed interest in this from the WebGL WG, so I'm taking a shot at moving this along.

Much of this is advised by some thought I've been putting into our story for sRGB and WebGL: https://hackmd.io/@jgilbert/sRGB-WebGL

A bunch of changes here, so there'll be a lot to talk about.
* Splitting out attribs into [color-space, encoding, linearity] adds specificity at some cost of verbosity and an increase of jargon.
* Remove linear=physical association, which is a common source of confusion (and contention between APIs).
* Decouple radiance-linearity from rec2020, and make rec2020 match the CSS color spec. (Therefore it no longer uses sRGB primaries)
* Added clarifying language about encoding-vs-value and operations

I wouldn't call this done, but we'd love to get this moving again.

Cc: @kenrussell, @grorg, @RafaelCintron, @MarkCallow
