### PR TITLE
Remove older details

### DIFF
--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -25,7 +25,7 @@
 ## Proposed Solution
 
 * Clearly define the default color space of canvases to be ``srgb``, and the default encoding to be 8 bits per pixel.
-* Add canvas context creation attributes to change the color space and encoding of a canvas.
+* Add canvas context creation attributes to specify the color space and encoding of a canvas.
 * Clarify behavior for drawing into canvases, compositing canvases, and exporting canvas contents.
 * Add mechanisms to specify the color space and encoding of ``ImageData`` objects.
 
@@ -111,7 +111,7 @@ The ``colorEncoding`` attribute specifies the encoding to be used for storing pi
 
 * Values stored in WebGL backbuffers are in the canvas's color space.
 * Values written by ``gl_FragColor`` use the primaries of the canvas' color space.
-* For the color encoding of ``"unorm-srgb8"``, the interpretation of values written by ``gl_FragColor`` is as follows:
+* For the color encoding of ``"unorm8-srgb"``, the interpretation of values written by ``gl_FragColor`` is as follows:
   * The color value is in a linear color space.
   * The inverse sRGB transfer function is applied only after blending has occurred.
   * E.g, if the value ``0.5`` is written in ``gl_FragColor``, the result will be stored as ``0xbc``.
@@ -119,7 +119,7 @@ The ``colorEncoding`` attribute specifies the encoding to be used for storing pi
 
 #### Compositing the canvas element
 
-Canvas contents are composited in accordance with the canvas element's style (e.g. CSS compositing and blending rules). The necessary compositing operations must be performed in an intermediate colorspace, the compositing space, that is implementation specific. The compositing space must have sufficient precision and a sufficiently wide gamut to guarantee no undue loss of precision or gamut clipping in bringing the canvas's contents to the display.
+Canvas contents are composited in accordance with the canvas element's style (e.g. CSS compositing and blending rules). The necessary compositing operations must be performed in an intermediate colorspace, the compositing space, that is implementation specific. The compositing space must have sufficient precision and a sufficiently wide gamut to guarantee no undue loss of precision or gamut clipping in bringing the canvas's contents to the display. Implementations should not expose color spaces that are unreasonble for the display.
 
 #### Feature detection
 

--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -111,7 +111,7 @@ The ``colorEncoding`` attribute specifies the encoding to be used for storing pi
 
 * Values stored in WebGL backbuffers are in the canvas's color space.
 * Values written by ``gl_FragColor`` use the primaries of the canvas' color space.
-* For the color encoding of ``"unorm-srgb"``, the interpretation of values written by ``gl_FragColor`` is as follows:
+* For the color encoding of ``"unorm-srgb8"``, the interpretation of values written by ``gl_FragColor`` is as follows:
   * The color value is in a linear color space.
   * The inverse sRGB transfer function is applied only after blending has occurred.
   * E.g, if the value ``0.5`` is written in ``gl_FragColor``, the result will be stored as ``0xbc``.

--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -111,7 +111,7 @@ The ``colorEncoding`` attribute specifies the encoding to be used for storing pi
 
 * Values stored in WebGL backbuffers are in the canvas's color space.
 * Values written by ``gl_FragColor`` use the primaries of the canvas' color space.
-* The encodings for specific color value differ between ``"unorm8"`` and ``"unorm8-srgb"``.
+* The encodings for specific color values differ between ``"unorm8"`` and ``"unorm8-srgb"``.
 * For ``"unorm8"``, the color encoding function is:
 <pre>
 function encodeUnorm8(val) { return val * 0xff; }

--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -3,6 +3,7 @@
 ## Use Case Description
 * Contents displayed through a canvas element should be in a well-defined color space to minimize differences in appearance across browsers and display devices.
 * Canvases should be able to take advantage of the full color gamut and dynamic range of the display device.
+* Contents displayed through a canvas element should be color managed in order to minimize differences in appearance across browsers and display devices. Improving color fidelity matters for artistic (e.g, photo and paint apps) and for e-commerce (e.g, product presentation) use cases.
 
 ### Current Limitations
 * The color space of canvases is undefined in the current specification, although is de facto sRGB.
@@ -13,6 +14,9 @@
 
 * <cite>[https://github.com/whatwg/html/issues/299]</cite> <blockquote><p>Allow 2dcontexts to use deeper color buffers</p></blockquote>
 * <cite>[https://bugs.chromium.org/p/chromium/issues/detail?id=425935]</cite> <blockquote><p>Wrong color profile with 2D canvas</p></blockquote>
+* Engineers from the Google Photos, Maps and Sheets teams have expressed a desire for canvases to be color managed. Particularly for the use case of resizing an image, using a canvas, prior to uploading it to the server, to save bandwidth. The problem is that the images retrieved from a canvas are in an undefined color space and no color space information is encoded by toDataURL or toBlob.
+
+
 
 ### Related Specifications
 * The [CSS Media Queries Level 5](https://www.w3.org/TR/mediaqueries-5/#color-gamut) specification defines the ``color-gamut`` media query to determine the capabilities of the current display device.

--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -1,52 +1,29 @@
 # Color managing canvas contents
 
 ## Use Case Description
-* Contents displayed through a canvas element should be color managed in order to minimize differences in appearance across browsers and display devices. Improving color fidelity matters a lot for artistic uses (e.g. photo and paint apps) and for e-commerce (product presentation).
+* Contents displayed through a canvas element should be in a well-defined color space to minimize differences in appearance across browsers and display devices.
 * Canvases should be able to take advantage of the full color gamut and dynamic range of the display device.
 
 ### Current Limitations
-* The color space of canvases is undefined in the current specification, though de facto sRGB.
-* The bit-depth of canvases is currently fixed to 8 bits per component, which is below the capabilities of some monitors. Monitors with higher contrast ratios require more bits per component to avoid banding.
-* Color encoding and blending is de facto perceptually-linear unorm8, which allocates too little precision on low values (and too much precision on high values), leading to poor handling of dark scenes and content.
-
-### Current Usage and Workarounds
-The lack of color space interoperability is hard to work around. For some browser implementations which color-correct images drawn to canvases by applying the display profile, apps that want to use canvases for color corrected image processing are stuck doing convoluted workarounds, such as:
-* reverse-engineer the display profile by drawing test pattern images to the canvas and inspecting the color corrected result via getImageData
-* bypass CanvasRenderingContext2D.drawImage() and use image decoders implemented in JavaScript to extract raw image data that was not tainted by the browser's color correction behavior.''
-
-An aspect of current implementations that is interoperable is that colors match between CSS/HTML and canvases:
-* A color value used as a canvas drawing style will have the same appearance as if the same color value were used as a CSS style
-* An image resource drawn to a canvas element will have the same appearance as if it were displayed as the replaced content of an HTML element or used as a CSS style value.
-
-This color matching behavior needs to be preserved to avoid breaking pre-existing content.
-
-Some implementations convert images drawn to canvases to the sRGB color space. This has the advantage of making the color correction behavior device independent, but it clamps the gamuts of the rendered content to the sRGB gamut, which is significantly narrower than the gamuts of some current consumer devices.
+* The color space of canvases is undefined in the current specification, although is de facto sRGB.
+* The bit-depth of canvases is likewise undefined, although is de facto 8 bits per component.
+* Images retrieved from a canvas are in an undefined color space and no color space information is encoded by ``toDataURL`` or ``toBlob``.
 
 ### Requests for this Feature
 
 * <cite>[https://github.com/whatwg/html/issues/299]</cite> <blockquote><p>Allow 2dcontexts to use deeper color buffers</p></blockquote>
 * <cite>[https://bugs.chromium.org/p/chromium/issues/detail?id=425935]</cite> <blockquote><p>Wrong color profile with 2D canvas</p></blockquote>
-* Engineers from the Google Photos, Maps and Sheets teams have expressed a desire for canvases to become color managed.  Particularly for the use case of resizing an image, using a canvas, prior to uploading it to the server, to save bandwidth. The problem is that the images retrieved from a canvas are in an undefined color space and no color space information is encoded by toDataURL or toBlob.
 
-## Background
-
-Color spaces are generally tuples of:
-* Chromaticity coordinates (X,Y in CIE 1931 space)
-  * Primaries (coords for 1.0 for each of R/G/B)
-  * White-point (coord for white)
-* Transfer function (often "gamma")
-
-Within the same chromaticity, 0.0 will always be min-brightness and 1.0 is max-brightness.
-However, because of the transfer function, 0.5 will not be the average physical brightness of 0.0 and 1.0.
-You can see this by making stripes of 1.0 and 0.0, and matching that pattern's brightness to a solid grey background.
-(On my machine, striped 0/1/0/1 appears equally bright as #ACACAC, or 0.67)
+### Related Specifications
+* The [CSS Media Queries Level 5](https://www.w3.org/TR/mediaqueries-5/#color-gamut) specification defines the ``color-gamut`` media query to determine the capabilities of the current display device.
+* The [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4) specification defines several color spaces that will be used in this specification. At time of writing this specification is partially implemented on some browsers.
 
 ## Proposed Solution
 
-* Clearly define the color space of canvases.  Most current browser implementations are either color-managed or are currently actively working on becoming color-managed.  Therefore, it will be possible to specify that the default color space of canvases as 'srgb' instead of leaving it undefined in the spec (as is currently the case due to lack of interoperability).
-* Add a canvas context creation attribute to specify a color space.
-* Add a canvas context creation attribute to specify an encoding format for storing pixel values.
-* Color space and encoding format parameters are also extended to image storage interfaces that interact with canvases, such as CanvasPattern, ImageData and ImageBitmap.
+* Clearly define the default color space of canvases to be ``srgb``, and the default encoding to be 8 bits per pixel.
+* Add canvas context creation attributes to change the color space and encoding of a canvas.
+* Clarify behavior for drawing into canvases, compositing canvases, and exporting canvas contents.
+* Add mechanisms to specify the color space and encoding of ``ImageData`` objects.
 
 ### Processing Model
 
@@ -103,61 +80,48 @@ canvas.getContext('2d', { colorSpace: "rec2020",
                           colorEncoding: "float16"} );
 </pre>
 
-#### The colorSpace canvas creation parameter
+#### The ``colorSpace`` canvas creation attribute
 
-* Color spaces match their respective counterparts as defined in the [CSS colorspaces](https://www.w3.org/TR/css-color-4/#predefined).
-* All input colors (e.g, fillStyle or strokeStyle, and gradient stops) follow the same interpretation as CSS color literals, regardless of canvas color space.
-* Values written to WebGL backbuffers (e.g, values written to gl_FragColor or the clear color) are in the canvas's color space.
-* Images with no color profile, when drawn to the canvas, are assumed to be in the sRGB color space.
-* Unless otherwise explicitly specified by the user, toDataURL/toBlob will produce resources in sRGB color space, with unorm8 encoding (matching existing behavior). If the destination image format supports colorspace tagging or embedded color profiles, the resource will be tagged as being in sRGB color space.
+The ``colorSpace`` attribute specifies the color space for the backing storage of the canvas.
+* Color spaces match their respective counterparts as defined in the [predefined color spaces](https://www.w3.org/TR/css-color-4/#predefined) section of the [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4) specification.
+* When an unsupported color space is requested, the color space shall fall back to ``"srgb"``.
 
-##### The "srgb" color space
-* This color space matches the existing canvas behavior.
-* Guarantees that color values used as fillStyle or strokeStyle exactly match the appearance of the same color value when it is used in CSS.
-* On implementations that do not color-manage CSS colors, the canvas "srgb" color space must not be color-managed either, in order to preserve color-matching between CSS and canvas-rendered content. This situation shall be referred to as the "legacy behavior".
-* All content drawn into such a 2d canvas RC must be color corrected to sRGB.
-    * Exception: User agents that implement the legacy behavior must apply color correction steps that match the color correction that is applied to image resources that are displayed via CSS.
-* Displayed canvases must be color corrected for the display if a display color profile is available. This color correction happens downstream at the compositing stage, and has no script-visible side-effects.
-* toDataURL/toBlob produce resources tagged as being in the sRGB color space, if the encoding format supports colorspace tagging or embedded color profiles.
-    * Exception: User agents that implement the legacy behavior must not encode any color space metadata.
+#### The ``colorEncoding`` canvas creation attribute
 
-##### The "rec-2020" color space
-* As per the [CSS rec-2020 color space](https://www.w3.org/TR/css-color-4/#valdef-color-rec-2020).
-* This color space has different primaries and a different transfer function than "srgb".
-* Support is optional, and should not be present on srgb-only UAs.
+The ``colorEncoding`` attribute specifies the encoding to be used for storing pixel channel color values.
+* Support for ``"unorm8"`` is mandatory. All other encodings are optional.
+* When an unsupported encoding is requested, the encoding shall fall back to ``"unorm8"``.
 
+#### 2D canvas behavior
 
-#### The colorEncoding context creation attribute
-The colorEncoding attributes specifies the encoding to be used for storing pixel channel color values.
-* Support for "unorm8" is mandatory. All other encodings are optional.
-* When an unsupported encoding is requested, the encoding shall fall back to "unorm8".
-* The alpha channel is always interpreted as if clamped to [0,1].
-* Float RGB channel values outside of [0,1] range can be used to represent colors outside of the chosen color gamut. This allows float pixel formats to represent all possible colors and brightness levels. How values outside of [0,1] are displayed depends on the capabilites of the device and output display. Some implementations may simply clamp these values to [0,1]. If the device and display are capable, a (perceptually-linear) pixel value of (2,2,2) should be twice as bright as (1,1,1).
-* Operations on encoded values always operate on decoded values, not the encoded bits.
-    * I.e. in "unorm8-srgb" encoding, 0xff (1.0) minus 0xbc (0.5) equals 0xbc (0.5).
+* All input colors (e.g, ``fillStyle`` and ``strokeStyle``) follow the same interpretation as CSS color literals, regardless of the canvas color space.
+* Images drawn to a canvas are converted from their native color space to the backing storage color space of the canvas.
+  * Images with no color profile, when drawn to the canvas, are assumed to be in the sRGB color space.
+* All blending operations are performed in the canvas' backing storage color space.
+  * The midpoint between the backbuffer's colors ``(1,0,0)`` and ``(0,1,0)`` will be ``(0.5,0.5,0)``, even though this is neither the physical nor perceptual midpoint between the two colors.
+  * This means that the same content, rendered with two different canvas backing stores, may be slightly different.
+* The functions ``toDataURL`` and ``toBlob`` should produce resources that best match the fidelity of the underlying canvas.
+  * Subject to the limitations of the implementation and the requested format.
 
+#### WebGL behavior
 
-#### Selecting the best color space match for the user agent's display device
-<pre>
-var colorSpace = window.matchMedia("(color-gamut: rec2020)").matches ? "rec2020" :
-    (window.matchMedia("(color-gamut: p3)").matches ? "p3" : "srgb");
-</pre>
-
-#### Selecting the best encoding for the user agent's display device
-Selection should be based on the best color space match (see above). For srgb, at least 8 bits per component is recommended; for p3, 10 bits; and for rec2020, 12 bits.  The float16 format is suitable for any colorspace.  There may soon be a proposal to add a way of detecting HDR displays, possibly something like "window.screen.isHDR()" (TBD), which would be a good hint to use the float16 format.
-
-#### Non-standard color spaces
-For future consideration: support could be added for color space defined using the [CSS @color-profile rule](https://www.w3.org/TR/css-color-4/#at-profile).
+* Values stored in WebGL backbuffers are in the canvas's color space.
+* Values written by ``gl_FragColor`` use the primaries of the canvas' color space.
+* For the color encoding of ``"unorm-srgb"``, the interpretation of values written by ``gl_FragColor`` is as follows:
+  * The color value is in a linear color space.
+  * The inverse sRGB transfer function is applied only after blending has occurred.
+  * E.g, if the value ``0.5`` is written in ``gl_FragColor``, the result will be stored as ``0xbc``.
+* For all other color encodings, the value written by ``gl_FragColor`` is in the canvas' color space.
 
 #### Compositing the canvas element
-Canvas contents are composited in accordance with the canvas element's style (e.g. CSS compositing and blending rules). The necessary compositing operations must be performed in an intermediate colorspace, the compositing space, that is implementation specific. The compositing space must have sufficient precision and a sufficiently wide gamut to guarantee no undue loss of precision or gamut clipping in bringing the canvas's contents to the display. Implementations should not expose color spaces that are unreasonble for the display.
+
+Canvas contents are composited in accordance with the canvas element's style (e.g. CSS compositing and blending rules). The necessary compositing operations must be performed in an intermediate colorspace, the compositing space, that is implementation specific. The compositing space must have sufficient precision and a sufficiently wide gamut to guarantee no undue loss of precision or gamut clipping in bringing the canvas's contents to the display.
 
 #### Feature detection
-2D rendering contexts are to expose a new getContextAttributes() method, that works much like the method of the same name on WebGLRenderingContext. The method returns the "actual context attributes" which represents the settings that were successfully applied at context creation time. The settings attribute reflects the result of running the algorithm for coercing the settings argument for 2D contexts, as well as the result of any fallbacks that may have happened as a result of options not being supported by the UA.
 
-Web apps may infer that a user agent that does not implement getContextAttributes() does not support the colorSpace and pixelFormat attributes.
+2D rendering contexts are to expose a new ``getContextAttributes`` method that works much like the method of the same name on WebGLRenderingContext. The method returns the true context attributes, which represent the settings that were successfully applied at context creation time.
 
-Note: An alternative approach that was considered was to augment the probablySupportsContext() API by making it check the second argument.  That approach is difficult to consolidate with how dictionary arguments are meant to work, where unsupported entries are just ignored.
+Web apps may infer that a user agent that does not implement ``getContextAttributes`` does not support the colorSpace and pixelFormat attributes.
 
 #### ImageBitmap
 
@@ -219,6 +183,13 @@ The changes to this interface are the addion of the optional ``ImageDataSettings
 
 The ``getImageData`` method is responsible for converting the data from the canvas' internal format to the format requested in the ``ImageDataSettings``.
 
+### Examples
+
+#### Selecting the best color space match for the user agent's display device
+<pre>
+var colorSpace = window.matchMedia("(color-gamut: rec2020)").matches ? "rec-2020" :
+                (window.matchMedia("(color-gamut: p3)").matches ? "display-p3" : "srgb");
+</pre>
 
 ### Limitations
 * toDataURL and toBlob may be lossy, depending on the file format, when used on a canvas that has a storage type other than ``"uint8"``. Possible future improvements could solve or mitigate this issue by adding more file formats or adding options to specify the resource color space.

--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -111,11 +111,19 @@ The ``colorEncoding`` attribute specifies the encoding to be used for storing pi
 
 * Values stored in WebGL backbuffers are in the canvas's color space.
 * Values written by ``gl_FragColor`` use the primaries of the canvas' color space.
-* For the color encoding of ``"unorm8-srgb"``, the interpretation of values written by ``gl_FragColor`` is as follows:
-  * The color value is in a linear color space.
-  * The inverse sRGB transfer function is applied only after blending has occurred.
-  * E.g, if the value ``0.5`` is written in ``gl_FragColor``, the result will be stored as ``0xbc``.
-* For all other color encodings, the value written by ``gl_FragColor`` is in the canvas' color space.
+* The encodings for specific color value differ between ``"unorm8"`` and ``"unorm8-srgb"``.
+* For ``"unorm8"``, the color encoding function is:
+<pre>
+function encodeUnorm8(val) { return val * 0xff; }
+</pre>
+* For ``"unorm8-srgb"``, the color encoding function is:
+<pre>
+function encodeUnorm8Srgb(val) {
+  if (val < 0.0031308) return 12.92 * val * 0xff;
+  return (1.055 * Math.pow(val, 0.41666) - 0.055) * 0xff;
+}
+</pre>
+* For all color encodings, the values stored in the framebuffer are in the canvas' color space.
 
 #### Compositing the canvas element
 


### PR DESCRIPTION
This spec is several years old and has accumulated some cruft. Clear some of it out. Also, remove extra background information and definitions. This information is helpful, but is currently cluttering the spec, and we are trying to pin down the behavior changes.

In particular:
* From "Current Limitations", remove remarks about perceptual-linear unorm8 encoding, because the stored encoding of 8-bit contents is unchanged by this specification (unorm8-srgb affects only blending and fragment math space).
* Remove "Current Usage and Workarounds" section. Most of the behavior documented in this section is obsolete.
* Shorten "Requests for this Feature" section to not specify particular vendor applications.
* Remove the "Background" section and replace with a "Related Specifications" section. Do not define the color spaces in this document, rather, link to the CSS Color Level 4 specification.
* Move the "Selecting the best color space match for the user agent's display device" to an "Examples" section at the end. Remove speculation about a TBD isHDR method.
* Remove discussions of "srgb" and "rec-2020" color spaces.
* Separate subsections for "2D canvas behavior" versus "WebGL behavior", since the effects of the spec are different on the two.
* Move discussion of srgb-encoded pixel values to WebGL behavior section.
* Clarify that undefined or unsupported color spaces should default to srgb with unorm8.
* Remove the advice that "Implementations should not expose color spaces that are unreasonable for the display".