### PR TITLE
ImageDataStorageType renaming

### DIFF
--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -178,14 +178,14 @@ ImageBitmap objects (unless created with ``colorSpaceConversion="none"``) should
 
 Add the following types to be used by `ImageData`.
 <pre>
-enum ImageDataStorageType {
-  "uint8", // default
-  "uint16",
+enum ImageDataStorageFormat {
+  "unorm8", // default
+  "unorm16",
   "float32",
 };
 dictionary ImageDataSettings {
   CanvasColorSpaceEnum colorSpace = "srgb";
-  ImageDataStorageType storageType = "uint8";
+  ImageDataStorageFormat storageFormat = "unorm8";
 };
 typedef (Uint8ClampedArray or Uint16Array or Float32Array) ImageDataArray;
 </pre>
@@ -205,16 +205,16 @@ The changes to this interface are:
 * The ImageDataSettings attribute may be queried using `getImageDataSettings`.
 * The constructor and attribute that used to be a `Uint8ClampedArray` are now a `ImageDataArray` union, which can specify data in multiple formats.
 
-The type of the ``data`` attribute is determined by the ``storageType`` parameter according to the following table.
+The type of the ``data`` attribute is determined by the ``storageFormat`` parameter according to the following table.
 
-| ``storageType`` Value | ``data`` Type |
+| ``storageFormat`` Value | ``data`` Type |
 |-|-|
-| ``"uint8"`` | ``Uint8ClampedArray`` |
-| ``"uint16"`` | ``Uint16Array`` |
+| ``"unorm8"`` | ``Uint8ClampedArray`` |
+| ``"unorm16"`` | ``Uint16Array`` |
 | ``"float32"`` | ``Float32Array`` |
 
 
-The constructor that takes both an `ImageDataArray` and an `ImageDataSettings` will throw an exception if the type of the `ImageDataArray` is incompatible with the type specified in `ImageDataSettings` (e.g, `ImageDataArray` is a `Float32Array`, but `ImageDataSettings` specifies ``storageType="uint8"``).
+The constructor that takes both an `ImageDataArray` and an `ImageDataSettings` will throw an exception if the type of the `ImageDataArray` is incompatible with the type specified in `ImageDataSettings` (e.g, `ImageDataArray` is a `Float32Array`, but `ImageDataSettings` specifies ``storageFormat="unorm8"``).
 
 When an ``ImageData`` is used in a canvas (e.g, in ``putImageData``), the data is converted from the ``ImageData``'s color space to the color space of the canvas.
 
@@ -226,7 +226,7 @@ partial interface CanvasRenderingContext2D {
 }
 </pre>
 
-The changes to this interface are the addion of the optional ``ImageDataSettings`` argument. If this argument is unspecified, then the default values of ``storageType="uint8"`` and ``colorSpace="srgb"`` will be used (these defaults match previous behavior).
+The changes to this interface are the addion of the optional ``ImageDataSettings`` argument. If this argument is unspecified, then the default values of ``storageFormat="unorm8"`` and ``colorSpace="srgb"`` will be used (these defaults match previous behavior).
 
 The ``getImageData`` method is responsible for converting the data from the canvas' internal format to the format requested in the ``ImageDataSettings``.
 
@@ -239,7 +239,7 @@ var colorSpace = window.matchMedia("(color-gamut: rec2020)").matches ? "rec-2020
 </pre>
 
 ### Limitations
-* toDataURL and toBlob may be lossy, depending on the file format, when used on a canvas that has a storage type other than ``"uint8"``. Possible future improvements could solve or mitigate this issue by adding more file formats or adding options to specify the resource color space.
+* toDataURL and toBlob may be lossy, depending on the file format, when used on a canvas that has a storage type other than ``"unorm8"``. Possible future improvements could solve or mitigate this issue by adding more file formats or adding options to specify the resource color space.
 
 ### Adoption
 Lack of color management and color interoperability is a longstanding complaint about the canvas API.


### PR DESCRIPTION
Rename ImageDataStorageType to ImageDataStorageFormat. This matches corresponding CanvasStorageFormat.

Also change uint8 and uint16 to unorm8 and unorm16. This matches CanvasStorageFormat names, and is also a better choice, because it is more descriptive, and doesn't preclude other uses of Uint16Array (e.g, for actual-unsigned-integer values, or for R5G6B5, or half-float).