### PR TITLE
Replace rec-2020 with rec2020

### DIFF
--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -36,7 +36,7 @@ IDL:
 enum CanvasColorSpaceEnum {
   "srgb", // default
   "display-p3",
-  "rec-2020",
+  "rec2020",
 };
 
 enum CanvasStorageFormatEnum {
@@ -51,7 +51,7 @@ enum CanvasStorageFormatEnum {
 interface CanvasColorSpace {
   const CanvasColorSpaceEnum srgb = "srgb";
   const CanvasColorSpaceEnum displayP3 = "display-p3";
-  const CanvasColorSpaceEnum rec2020 = "rec-2020";
+  const CanvasColorSpaceEnum rec2020 = "rec2020";
 };
 
 interface CanvasStorageFormat {
@@ -215,7 +215,7 @@ The ``getImageData`` method is responsible for converting the data from the canv
 
 #### Selecting the best color space match for the user agent's display device
 <pre>
-var colorSpace = window.matchMedia("(color-gamut: rec2020)").matches ? "rec-2020" :
+var colorSpace = window.matchMedia("(color-gamut: rec2020)").matches ? "rec2020" :
                 (window.matchMedia("(color-gamut: p3)").matches ? "display-p3" : "srgb");
 </pre>
 
@@ -238,7 +238,7 @@ Authors of games and imaging apps are expected to be enthusiastic adopters.
 
 * Should context creation throw on an unrecognized, non-undefined creation attribute?
 
-* The [Media Query APIs](https://www.w3.org/TR/mediaqueries-4/) use the names "p3" and "rec2020", while the [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#predefined) uses the names "display-p3" and "rec-2020". This divergence could be confusing.
+* The [Media Query APIs](https://www.w3.org/TR/mediaqueries-4/) use the name "p3", while the [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#predefined) uses the name "display-p3". This divergence could be confusing.
 
 ## Proposal History
 


### PR DESCRIPTION
This is a typo that snuck in at some point.